### PR TITLE
Add option to disable tests during builds

### DIFF
--- a/nymea-remoteproxy.pro
+++ b/nymea-remoteproxy.pro
@@ -1,7 +1,11 @@
 include(nymea-remoteproxy.pri)
 
 TEMPLATE=subdirs
-SUBDIRS += server client libnymea-remoteproxy libnymea-remoteproxyclient tests
+SUBDIRS += server client libnymea-remoteproxy libnymea-remoteproxyclient 
+
+!disabletests {
+    SUBDIRS+=tests
+}
 
 !disablemonitor {
     SUBDIRS+=monitor


### PR DESCRIPTION
yocto doesn't deal well with the -rpath option... let's allow disable building those tests, they're not ran during yocto builds anyways.