### PR TITLE
String conversion of m_tunnelPartnerUuid problem

### DIFF
--- a/libnymea-remoteproxyclient/remoteproxyconnection.cpp
+++ b/libnymea-remoteproxyclient/remoteproxyconnection.cpp
@@ -135,7 +135,7 @@ QString RemoteProxyConnection::tunnelPartnerName() const
 
 QString RemoteProxyConnection::tunnelPartnerUuid() const
 {
-    return m_tunnelPartnerUuid;
+    return "{" + m_tunnelPartnerUuid + "}";
 }
 
 void RemoteProxyConnection::cleanUp()


### PR DESCRIPTION
in remoteproxyconnection.cpp there is no proper toString conversion,
resulting in missing brackets in the outputed string.

This fixes it somewhat, but is no long term solution.
This maybe also be dependent on the version of Qt that the application
is compiled with.

Fixes #25 